### PR TITLE
Use a pxc-bootstrap option with percona

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -166,7 +166,7 @@ class galera(
     # needs to be bootstrapped. This happens before the service is managed
     $server_list = join($galera_servers, ' ')
     exec { 'bootstrap_galera_cluster':
-      command   => 'service mysql start --wsrep_cluster_address=gcomm://',
+      command   => $galera::params::bootstrap_command, 
       onlyif    => "ret=1; for i in ${server_list}; do nc -z \$i ${wsrep_group_comm_port}; if [ \"\$?\" = \"0\" ]; then ret=0; fi; done; /bin/echo \$ret | /bin/grep 1 -q",
       require   => Class['mysql::server::config'],
       before    => [Class['mysql::server::service'], Service['mysqld']],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,12 @@
 class galera::params {
   $server_csl = join($galera::galera_servers, ',')
 
+  if $galera::vendor_type == 'percona' {
+    $bootstrap_command = '/etc/init.d/mysql bootstrap-pxc'
+  } elsif $galera::vendor_type == 'mariadb' {
+    $bootstrap_command = 'service mysql start --wsrep_cluster_address=gcomm://'
+  }
+
   if ($::osfamily == 'RedHat') {
     $mysql_service_name = 'mysql'
     $nc_package_name = 'nc'


### PR DESCRIPTION
Percona's init scripts do not support arguments,
but the percona packages include a bootstrap script
that can be used in its place. This patch uses that
script for the bootstrapping Exec resource when the
percona vendor is used.
