### PR TITLE
Prevent mysql::server::restart from being set

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,6 +78,11 @@
 #   user used during updates.
 #   Defaults to 'sysmaint'
 #
+# [*mysql_restart*]
+#   (optional) The option to pass through to mysql::server::restart
+#   This can cause issues during bootstrapping if switched on.
+#   Defaults to false
+#
 class galera(
   $galera_servers                   = [$::ipaddress_eth1],
   $galera_master                    = $::fqdn,
@@ -95,7 +100,8 @@ class galera(
   $configure_firewall               = true,
   $deb_sysmaint_password            = 'sysmaint',
   $validate_connection              = true,
-  $status_check                     = true
+  $status_check                     = true,
+  $mysql_restart                    = false
 )
 {
   if $configure_repo {
@@ -141,6 +147,7 @@ class galera(
     override_options    => $options,
     root_password       => $root_password,
     service_name        => $galera::params::mysql_service_name,
+    restart             => $mysql_restart,
   }
 
   file { $galera::params::rundir:

--- a/spec/classes/galera_init_spec.rb
+++ b/spec/classes/galera_init_spec.rb
@@ -18,6 +18,7 @@ describe 'galera' do
       :configure_repo                => true,
       :configure_firewall            => true,
       :deb_sysmaint_password         => 'sysmaint',
+      :mysql_restart                 => false,
     }
   end
 


### PR DESCRIPTION
If mysql is allowed to restart services, on the node
that is responsible for bootstrapping this will cause
issues, since a 'service mysql restart' will take the
cluster down, but will not bring it back up.

The parameter is left as an option, as it may be
desirable in some circumstances.

Note that this does mean that the galera cluster will
not pick up config changes automatically, as config
changes will not trigger a restart of services.
