### PR TITLE
Add OSP5 native package support

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -69,6 +69,9 @@ class galera::repo(
           }
         }
       }
+      if ($repo_vendor == 'osp5') {
+        fail('OSP5 is only supported on RHEL platforms.')
+      }
     }
 
     'RedHat': {

--- a/manifests/validate.pp
+++ b/manifests/validate.pp
@@ -69,7 +69,7 @@ class galera::validate(
     command       => $cmd,
     tries         => $retries,
     try_sleep     => $delay,
-    subscribe     => Service['mysql'],
+    subscribe     => Service['mysqld'],
     refreshonly   => true,
     before        => Anchor['mysql::server::end'],
     require       => Class['galera::status']


### PR DESCRIPTION
Introduce support for use on RHEL 7 with OSP5 native packages of MariaDB
with Galera.
