### PR TITLE
Fix wsrep_sst_auth config

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -100,7 +100,7 @@ class galera::params {
         'wsrep_cluster_address'             => "gcomm://${server_csl}",
         'wsrep_slave_threads'               => '8',
         'wsrep_sst_method'                  => $galera::wsrep_sst_method,
-        'wsrep_sst_auth'                    => $wsrep_sst_auth,
+        'wsrep_sst_auth'                    => "\"${wsrep_sst_auth}\"",
         'binlog_format'                     => 'ROW',
         'default_storage_engine'            => 'InnoDB',
         'innodb_locks_unsafe_for_binlog'    => '1',


### PR DESCRIPTION
When I use wsrep_ss_auth variable without quotes, auth doesnt work

Tested with:
mariadb-galera-server-10.0          10.0.12+maria-1~trusty
galera                                            25.3.5-wheezy
