### PR TITLE
Support setting available_when_read_only.

### DIFF
--- a/manifests/status.pp
+++ b/manifests/status.pp
@@ -31,13 +31,21 @@
 #  from the cluster.
 #  Defaults to 0
 #
+# [*available_when_readonly*]
+#  (optional) When set to 0, clustercheck will return a 503
+#  Service Unavailable if the node is in the read_only state,
+#  as defined by the "read_only" mysql variable. Values other
+#  than 0 have no effect.
+#  Defaults to -1
+#
 class galera::status (
   $status_password  = 'statuscheck!',
   $status_allow     = '%',
   $status_host      = 'localhost',
   $status_user      = 'clustercheck',
   $port             = 9200,
-  $available_when_donor = 0,
+  $available_when_donor    = 0,
+  $available_when_readonly = -1,
 ) {
 
   mysql_user { "${status_user}@${status_allow}":

--- a/templates/clustercheck.erb
+++ b/templates/clustercheck.erb
@@ -20,7 +20,7 @@ MYSQL_PASSWORD="<%= @status_password %>"
 MYSQL_HOST="<%= @status_host %>"
 AVAILABLE_WHEN_DONOR="<%= @available_when_donor %>"
 ERR_FILE="${4:-/dev/null}"
-AVAILABLE_WHEN_READONLY=${5:-1}
+AVAILABLE_WHEN_READONLY="<%= @available_when_readonly %>"
 DEFAULTS_EXTRA_FILE=${6:-/etc/my.cnf}
 
 #Timeout exists for instances where mysqld may be hung


### PR DESCRIPTION
When available_when_readonly is set to 0, the clustercheck script will
return 503 Service Unavailable if the node is in read-only mode.
