### PR TITLE
Allow overriding of available_when_readonly

### DIFF
--- a/templates/clustercheck.erb
+++ b/templates/clustercheck.erb
@@ -20,7 +20,7 @@ MYSQL_PASSWORD="<%= @status_password %>"
 MYSQL_HOST="<%= @status_host %>"
 AVAILABLE_WHEN_DONOR="<%= @available_when_donor %>"
 ERR_FILE="${4:-/dev/null}"
-AVAILABLE_WHEN_READONLY="<%= @available_when_readonly %>"
+AVAILABLE_WHEN_READONLY="${AVAILABLE_WHEN_READONLY:-<%= @available_when_readonly %>}"
 DEFAULTS_EXTRA_FILE=${6:-/etc/my.cnf}
 
 #Timeout exists for instances where mysqld may be hung


### PR DESCRIPTION
There are cases when you need to override the default puppet setting for
available_when_readonly, such as when doing a rolling upgrade of mysql.
This allows the value to be set. We intentionally use an environment
variable rather than a positional one to avoid having to set the other
vars.
