### PR TITLE
change xinetd to systemd (excepted for FreeBSD)

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -8,4 +8,5 @@ fixtures:
     "provision": "https://github.com/puppetlabs/provision.git"
     "puppet_agent": "https://github.com/puppetlabs/puppetlabs-puppet_agent.git"
     "stdlib": "https://github.com/puppetlabs/puppetlabs-stdlib.git"
+    "xinetd": "https://github.com/puppetlabs/puppetlabs-xinetd.git"
     "yumrepo_core": "https://github.com/puppetlabs/puppetlabs-yumrepo_core.git"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -8,5 +8,4 @@ fixtures:
     "provision": "https://github.com/puppetlabs/provision.git"
     "puppet_agent": "https://github.com/puppetlabs/puppetlabs-puppet_agent.git"
     "stdlib": "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-    "xinetd": "https://github.com/puppetlabs/puppetlabs-xinetd.git"
     "yumrepo_core": "https://github.com/puppetlabs/puppetlabs-yumrepo_core.git"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.1.0]
+### Changed
+* Replace xinetd service by systemd service for all OS excepted FreeBSD. Compatiblity with EL9 (Redhat dropped xinetd on RHEL 9)
+
 ## [3.0.1]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [3.1.0]
+## [Unreleased]
 ### Changed
 * Replace xinetd service by systemd service for all OS excepted FreeBSD. Compatiblity with EL9 (Redhat dropped xinetd on RHEL 9)
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -574,4 +574,3 @@ Specifies the firewall source addresses to unblock. Valid options: a string. Def
 Default value: ``undef``
 
 ## Defined types
-

--- a/manifests/status.pp
+++ b/manifests/status.pp
@@ -36,19 +36,17 @@ class galera::status (
     }
   }
 
+
   group { 'clustercheck':
     ensure => present,
     system => true,
-  }
-
+  }->
   user { 'clustercheck':
     shell  => '/bin/false',
     home   => '/var/empty',
     gid    => 'clustercheck',
     system => true,
-    before => File['/usr/local/bin/clustercheck'],
-  }
-
+  }->
   file { '/usr/local/bin/clustercheck':
     content => epp('galera/clustercheck.epp'),
     owner   => 'clustercheck',
@@ -56,29 +54,41 @@ class galera::status (
     mode    => '0500',
   }
 
-  xinetd::service { 'mysqlchk':
-    server                  => '/usr/local/bin/clustercheck',
-    port                    => $galera::status_port,
-    user                    => 'clustercheck',
-    flags                   => 'REUSE',
-    service_type            => 'UNLISTED',
-    log_on_success          => $galera::status_log_on_success,
-    log_on_success_operator => $galera::status_log_on_success_operator,
-    log_on_failure          => $galera::status_log_on_failure,
-    require                 => [
-      File['/usr/local/bin/clustercheck'],
-      User['clustercheck']
-    ],
+  if $::osfamily == 'FreeBSD' {
+    File['/usr/local/bin/clustercheck'] -> xinetd::service { 'mysqlchk':
+        server                  => '/usr/local/bin/clustercheck',
+        port                    => $galera::status_port,
+        user                    => 'clustercheck',
+        flags                   => 'REUSE',
+        service_type            => 'UNLISTED',
+        log_on_success          => $galera::status_log_on_success,
+        log_on_success_operator => $galera::status_log_on_success_operator,
+        log_on_failure          => $galera::status_log_on_failure,
+    }
+    Exec<| title == 'bootstrap_galera_cluster' |> -> Class['xinetd']
   }
+  else {
+    File['/usr/local/bin/clustercheck'] -> file {'/lib/systemd/system/mysqlchk.socket':
+      mode => '0644',
+      owner => 'root',
+      group => 'root',
+      content => epp('galera/mysqlchk.socket.epp')
+    }->
+    file {'/lib/systemd/system/mysqlchk@.service':
+      mode => '0644',
+      owner => 'root',
+      group => 'root',
+      content => epp('galera/mysqlchk.service.epp')
+    }~>
+    exec { 'mysqlchk-systemd-reload':
+      command     => 'systemctl daemon-reload',
+      path        => [ '/usr/bin', '/bin', '/usr/sbin' ],
+      refreshonly => true,
+    }
 
-  # Postpone the xinetd stuff. This is necessary in order to avoid package
-  # conflicts. On some platforms xinetd depends on MySQL libs. If installed
-  # too early it will install the wrong MySQL libs. This may cause the
-  # installation of the Galera packages to fail.
-  # This has been first observed on Debian 9 with Codership Galera 5.7 where
-  # the package installation just ended with a conflict instead of replacing
-  # the wrong MySQL libs. The root cause is likely a packaging bug in the
-  # Codership distribution, since this issue could not be reproduced for
-  # Percona.
-  Exec<| title == 'bootstrap_galera_cluster' |> -> Class['xinetd']
+    # remove xinetd service
+    file {'/etc/xinetd.d/mysqlchk':
+      ensure => 'absent',
+    }
+  }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "fraenki-galera",
-  "version": "3.1.0",
+  "version": "3.0.1",
   "author": "Frank Wall",
   "summary": "Setup a Galera cluster on MySQL/MariaDB/XtraDB with Arbitrator support",
   "license": "BSD-2-Clause",
@@ -23,6 +23,10 @@
     {
       "name": "puppetlabs/firewall",
       "version_requirement": ">= 2.0.0 < 4.0.0"
+    },
+    {
+      "name": "puppetlabs/xinetd",
+      "version_requirement": ">= 3.0.0 < 4.0.0"
     },
     {
       "name": "puppetlabs/yumrepo_core",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "fraenki-galera",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "author": "Frank Wall",
   "summary": "Setup a Galera cluster on MySQL/MariaDB/XtraDB with Arbitrator support",
   "license": "BSD-2-Clause",
@@ -18,15 +18,11 @@
     },
     {
       "name": "puppetlabs/mysql",
-      "version_requirement": ">= 10.8.0 < 13.0.0"
+      "version_requirement": ">= 10.8.0 < 14.0.0"
     },
     {
       "name": "puppetlabs/firewall",
       "version_requirement": ">= 2.0.0 < 4.0.0"
-    },
-    {
-      "name": "puppetlabs/xinetd",
-      "version_requirement": ">= 3.0.0 < 4.0.0"
     },
     {
       "name": "puppetlabs/yumrepo_core",
@@ -56,20 +52,23 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "Rocky",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9"
       ]
     },
     {

--- a/spec/classes/galera_debian_spec.rb
+++ b/spec/classes/galera_debian_spec.rb
@@ -11,6 +11,21 @@ describe 'galera::debian' do
 
   shared_examples_for 'galera on Debian' do
     context 'with default parameters' do
+      it { is_expected.to contain_file('/lib/systemd/system/mysqlchk.socket').with_content(%r{ListenStream=9200}) }
+      it {
+        is_expected.to contain_file('/lib/systemd/system/mysqlchk@.service')
+          .with_content(%r{User=clustercheck})
+          .with_content(%r{Group=clustercheck})
+          .with_content(%r{ExecStart=/usr/local/bin/clustercheck})
+          .with_content(%r{StandardInput=socket})
+      }
+      it {
+        is_expected.to contain_exec('mysqlchk-systemd-reload').with(
+          'command'     => 'systemctl daemon-reload',
+          'path'        => ['/usr/bin', '/bin', '/usr/sbin'],
+          'refreshonly' => true,
+        )
+      }
       it { is_expected.to contain_file('/etc/mysql/puppet_debfix.cnf').with_content(%r{[mysqld]}) }
       it {
         is_expected.to contain_exec('clean_up_ubuntu').with(

--- a/spec/classes/galera_freebsd_spec.rb
+++ b/spec/classes/galera_freebsd_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+describe 'galera' do
+  let :params do
+    {
+      arbitrator_config_file: '/etc/default/garb',
+      arbitrator_package_name: 'galera-arbitrator',
+      arbitrator_service_name: 'garb',
+      bind_address: '10.2.2.1',
+      cluster_name: 'testcluster',
+      configure_firewall: true,
+      configure_repo: true,
+      deb_sysmaint_password: 'sysmaint',
+      galera_master: 'control1',
+      galera_servers: ['10.2.2.1'],
+      local_ip: '10.2.2.1',
+      mysql_port: 3306,
+      mysql_restart: false,
+      override_options: {},
+      root_password: 'test',
+      status_password: 'nonempty',
+      vendor_type: 'percona',
+      vendor_version: '5.7',
+      wsrep_group_comm_port: 4567,
+      wsrep_inc_state_transfer_port: 4568,
+      wsrep_sst_method: 'rsync',
+      wsrep_state_transfer_port: 4444,
+    }
+  end
+
+  shared_examples_for 'galera on FreeBSD' do
+    context 'when installing percona' do
+      it {
+        is_expected.to contain_xinetd__service('mysqlchk').with(
+          log_on_success: '',
+          log_on_success_operator: '=',
+          log_on_failure: nil,
+        )
+      }
+    end
+
+    context 'when specifying logging options' do
+      before(:each) do
+        params.merge!(status_log_on_success: 'PID HOST USERID EXIT DURATION TRAFFIC',
+                      status_log_on_success_operator: '-=',
+                      status_log_on_failure: 'USERID')
+      end
+      it {
+        is_expected.to contain_xinetd__service('mysqlchk').with(
+          log_on_success: 'PID HOST USERID EXIT DURATION TRAFFIC',
+          log_on_success_operator: '-=',
+          log_on_failure: 'USERID',
+        )
+      }
+    end
+  end
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do # rubocop:disable RSpec/EmptyExampleGroup
+      let(:facts) do
+        facts.merge({})
+      end
+
+      case facts[:osfamily]
+      when 'FreeBSD'
+        it_configures 'galera on FreeBSD'
+      end
+    end
+  end
+end

--- a/spec/classes/galera_init_spec.rb
+++ b/spec/classes/galera_init_spec.rb
@@ -51,14 +51,6 @@ describe 'galera' do
 
       it { is_expected.to contain_class('mysql::server') }
 
-      it {
-        is_expected.to contain_xinetd__service('mysqlchk').with(
-          log_on_success: '',
-          log_on_success_operator: '=',
-          log_on_failure: nil,
-        )
-      }
-
       it { is_expected.to contain_group('clustercheck').with(system: true) }
       it {
         is_expected.to contain_user('clustercheck').with(
@@ -261,21 +253,6 @@ describe 'galera' do
       before(:each) { params.merge!(configure_firewall: false) }
       it { is_expected.not_to contain_class('galera::firewall') }
       it { is_expected.not_to contain_firewall('4567 galera accept tcp') }
-    end
-
-    context 'when specifying logging options' do
-      before(:each) do
-        params.merge!(status_log_on_success: 'PID HOST USERID EXIT DURATION TRAFFIC',
-                      status_log_on_success_operator: '-=',
-                      status_log_on_failure: 'USERID')
-      end
-      it {
-        is_expected.to contain_xinetd__service('mysqlchk').with(
-          log_on_success: 'PID HOST USERID EXIT DURATION TRAFFIC',
-          log_on_success_operator: '-=',
-          log_on_failure: 'USERID',
-        )
-      }
     end
   end
 

--- a/templates/mysqlchk.service.epp
+++ b/templates/mysqlchk.service.epp
@@ -1,0 +1,10 @@
+[Unit]
+Description=Mysqlchk service
+After=network.target network-online.target
+Wants=network-online.target
+
+[Service]
+User=clustercheck
+Group=clustercheck
+StandardInput=socket
+ExecStart=/usr/local/bin/clustercheck

--- a/templates/mysqlchk.socket.epp
+++ b/templates/mysqlchk.socket.epp
@@ -1,0 +1,9 @@
+[Unit]
+Description=Mysqlchk socket
+
+[Socket]
+ListenStream=<%= $galera::status_port %>
+Accept=yes
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
Dear maintainer,

Redhat dropped support for `xinetd` on RHEL 9, so I've created the equivalent of xinetd service on systemd based OS.

There's a little test to avoid using systemd on FreeBSD.

It's possible some works needs to be done to actually merge this into your project, but I'm sharing what I've done.

Technical details:
* Systemd creats a socket listening on TCP/9200.
* Systemd will spawn a new instance of "mysqlchk@" service on each HTTP connection to the previously created socket. (see [systemd unit](https://www.freedesktop.org/software/systemd/man/systemd.unit.html) documentation for more details)
* I've tried to remove  the old xinetd service files to avoid conflicts.