### PR TITLE
duplication of key "galera::mariadb::default_options" in mapping

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -115,12 +115,10 @@ galera::percona::80::default_options:
 # Percona does not allow installation of wsrep-enabled server and wsrep provider.
 galera::percona::galera_package_ensure: 'absent'
 
-galera::mariadb::default_options:
-  mysqld:
-    wsrep_sst_auth: "\"<%= $wsrep_sst_auth_real %>\""
 galera::mariadb::galera_package_ensure: 'present'
 
 # binlog_format is deprecated in MySQL, but still required for MariaDB
 galera::mariadb::default_options:
   mysqld:
     binlog_format: 'ROW'
+    wsrep_sst_auth: "\"<%= $wsrep_sst_auth_real %>\""


### PR DESCRIPTION
`wsrep_sst_auth` is missing in `/etc/mysql/my.cnf` because of duplicated key `galera::mariadb::default_options` and only the latest is used and sets only `binlog_format: 'ROW'`