### PR TITLE
systemd: Ignore exit code of mysqlchk@.service instantiations

### DIFF
--- a/manifests/status.pp
+++ b/manifests/status.pp
@@ -95,7 +95,7 @@ class galera::status (
           'User'          => $galera::status_system_user,
           'Group'         => $galera::status_system_group,
           'StandardInput' => 'socket',
-          'ExecStart'     => $galera::status_script,
+          'ExecStart'     => "-${galera::status_script}",
         },
         require       => File[$galera::status_script],
       }

--- a/spec/classes/galera_debian_spec.rb
+++ b/spec/classes/galera_debian_spec.rb
@@ -43,7 +43,7 @@ describe 'galera' do
             'User' => 'clustercheck',
             'Group' => 'clustercheck',
             'StandardInput' => 'socket',
-            'ExecStart' => '/usr/local/bin/clustercheck',
+            'ExecStart' => '-/usr/local/bin/clustercheck',
           },
         )
       }

--- a/spec/classes/galera_redhat_spec.rb
+++ b/spec/classes/galera_redhat_spec.rb
@@ -50,7 +50,7 @@ describe 'galera' do
             'User' => 'clustercheck',
             'Group' => 'clustercheck',
             'StandardInput' => 'socket',
-            'ExecStart' => '/usr/local/bin/clustercheck',
+            'ExecStart' => '-/usr/local/bin/clustercheck',
           },
         )
       }


### PR DESCRIPTION
Recently, the support for systemd based status checking has been implemented.

Due to the way MariaDB Community Edition [implements the locking during a `mariabackup`](https://mariadb.com/kb/en/mariabackup-and-backup-stage-commands/) in comparison to MariaDB Enterprise Edition, it is possible, that during a `mariabackup` some instantiations of `mysqlchk@.service` will fail because the check for `wsrep_ready` briefly reports `OFF`.

This leads to the units failing and impeding the overall system state as seen by `systemctl status`:

```
● HOSTNAME
    State: degraded
    Units: 331 loaded (incl. loaded aliases)
     Jobs: 0 queued
   Failed: 1 units
    Since: Thu 2024-08-15 16:25:35 CEST; 4 weeks 1 day ago
  systemd: 252-32.el9_4.6
  Tainted: local-hwclock
   CGroup: /
```

and

```
root@HOSTNAME / # systemctl --failed
  UNIT                                                            LOAD   ACTIVE SUB    DESCRIPTION                            
● mysqlchk@708884-192.168.0.0:9220-192.168.0.0:34154.service loaded failed failed mysqlchk service (192.168.0.0:34154)
```

We therefore propose to not honor the exit code of the instantiations of `mysqlchk@.service`.

Cheers Thomas